### PR TITLE
Add fallback if `attachment_ids` array is not yet set

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@
 var gform_notification_attachment;
 jQuery( document ).ready(function(){
 	var element = jQuery('#gform_notification_attachment');
-	var attachment_ids = jQuery.parseJSON( element.find('.attachment_ids').val() );
+	var attachment_ids = jQuery.parseJSON( element.find('.attachment_ids').val() || '[]' );
 
 	// convert the attachment_ids from objects to arrays
 	attachment_ids = jQuery.makeArray( attachment_ids );


### PR DESCRIPTION
I know this plugin is pretty old but I still use it!  This fixes a being unable to attach files to new notifications.